### PR TITLE
Rust: fix tx ID assignment (0 was never assigned)

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -314,9 +314,9 @@ impl DNSState {
 
     pub fn new_tx(&mut self) -> DNSTransaction {
         let mut tx = DNSTransaction::new();
-        self.tx_id += 1;
         tx.id = self.tx_id;
-        return tx;
+        self.tx_id += 1;
+        tx
     }
 
     pub fn free_tx(&mut self, tx_id: u64) {

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -320,9 +320,9 @@ impl NFS3State {
 
     pub fn new_tx(&mut self) -> NFS3Transaction {
         let mut tx = NFS3Transaction::new();
-        self.tx_id += 1;
         tx.id = self.tx_id;
-        return tx;
+        self.tx_id += 1;
+        tx
     }
 
     pub fn free_tx(&mut self, tx_id: u64) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- This is a trivial change in the Rust code to increment tx id **after** assigning ID to the transaction. Otherwise, first transaction get ID 1, while suricata will request ID 0 as first valid ID.
- not sure if other parsers (C) are affected (I checked SMTP, it is not)


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

